### PR TITLE
Not search bounce mail when no query is specified.

### DIFF
--- a/app/controllers/bounce_mails_controller.rb
+++ b/app/controllers/bounce_mails_controller.rb
@@ -41,11 +41,17 @@ class BounceMailsController < ApplicationController
           end
         }
       else
-        @bounce_mails = BounceMail.select(:id, :timestamp, :recipient, :senderdomain, :addresser, :addresseralias, :reason, :digest, :subject, :softbounce,
-                                               'whitelist_mails.id AS whitelisted')
-                                  .joins('LEFT JOIN whitelist_mails' +
-                                         '  ON bounce_mails.recipient = whitelist_mails.recipient ' +
-                                         ' AND bounce_mails.senderdomain = whitelist_mails.senderdomain')
+        enable_bounce_mail_select_on_no_query = Rails.application.config.sisito.fetch(:enable_bounce_mail_select_on_no_query, true)
+        @bounce_mails =
+          if enable_bounce_mail_select_on_no_query
+            BounceMail.select(:id, :timestamp, :recipient, :senderdomain, :addresser, :addresseralias, :reason, :digest, :subject, :softbounce,
+                                                   'whitelist_mails.id AS whitelisted')
+                                      .joins('LEFT JOIN whitelist_mails' +
+                                             '  ON bounce_mails.recipient = whitelist_mails.recipient ' +
+                                             ' AND bounce_mails.senderdomain = whitelist_mails.senderdomain')
+          else
+            BounceMail.none
+          end
 
         if params[:reason].present?
           @reason = params[:reason]

--- a/app/controllers/bounce_mails_controller.rb
+++ b/app/controllers/bounce_mails_controller.rb
@@ -2,7 +2,7 @@ class BounceMailsController < ApplicationController
   before_action :set_bounce_mail, only: [:show]
 
   def index
-    @only_searched_bounce_mails = Rails.application.config.sisito.fetch(:only_searched_bounce_mails, false)
+    @show_all_bounce_mails = Rails.application.config.sisito.fetch(:show_all_bounce_mails, true)
     if params[:reason].present?
       cookies.delete(:query)
     else
@@ -42,11 +42,7 @@ class BounceMailsController < ApplicationController
           end
         }
       else
-        if @only_searched_bounce_mails
-          @bounce_mails = BounceMail.none
-          @reason = nil
-          @addresser = nil
-        else
+        if @show_all_bounce_mails
           @bounce_mails = BounceMail.select(:id, :timestamp, :recipient, :senderdomain, :addresser, :addresseralias, :reason, :digest, :subject, :softbounce,
                                                  'whitelist_mails.id AS whitelisted')
                                     .joins('LEFT JOIN whitelist_mails' +
@@ -64,6 +60,10 @@ class BounceMailsController < ApplicationController
           end
 
           @bounce_mails = @bounce_mails.order(timestamp: :desc).page(params[:page])
+        else
+          @bounce_mails = BounceMail.none
+          @reason = nil
+          @addresser = nil
         end
 
         @mask = !Rails.application.config.sisito.fetch(:authz).fetch(:disable_mask)

--- a/app/views/bounce_mails/_search_form.html.erb
+++ b/app/views/bounce_mails/_search_form.html.erb
@@ -10,21 +10,23 @@
   </div>
 </section>
 
-<section>
-  <%= form_tag bounce_mails_path, method: :get do %>
-    <div class="col-sm-8"></div>
-    <div class="col-sm-2">
-      <%= select_tag :addresser,
-            options_for_select([''] + BounceMail.group(:addresser).pluck(:addresser).sort, selected: @addresser),
-            class: 'form-control', onchange: 'this.form.submit()' %>
-    </div>
-    <div class="col-sm-2">
-      <%= select_tag :reason,
-            options_for_select([''] + Rails.application.config.sisimai[:reasons], selected: @reason),
-            class: 'form-control', onchange: 'this.form.submit()' %>
-    </div>
-  <% end %>
-</section>
+<% if !@only_searched_bounce_mails %>
+  <section>
+    <%= form_tag bounce_mails_path, method: :get do %>
+      <div class="col-sm-8"></div>
+      <div class="col-sm-2">
+        <%= select_tag :addresser,
+              options_for_select([''] + BounceMail.group(:addresser).pluck(:addresser).sort, selected: @addresser),
+              class: 'form-control', onchange: 'this.form.submit()' %>
+      </div>
+      <div class="col-sm-2">
+        <%= select_tag :reason,
+              options_for_select([''] + Rails.application.config.sisimai[:reasons], selected: @reason),
+              class: 'form-control', onchange: 'this.form.submit()' %>
+      </div>
+    <% end %>
+  </section>
+<% end %>
 
 <% if @bounce_mails.present? %>
   <section>

--- a/app/views/bounce_mails/_search_form.html.erb
+++ b/app/views/bounce_mails/_search_form.html.erb
@@ -10,7 +10,7 @@
   </div>
 </section>
 
-<% if !@only_searched_bounce_mails %>
+<% if @show_all_bounce_mails %>
   <section>
     <%= form_tag bounce_mails_path, method: :get do %>
       <div class="col-sm-8"></div>

--- a/config/sisito.yml
+++ b/config/sisito.yml
@@ -12,7 +12,7 @@ smtp:
     port: 25
     enable_starttls_auto: false
 default_recent_days: 14
-enable_bounce_mail_select_on_no_query: false
+only_searched_bounce_mails: true
 digest: sha1
 #mail_link: "https://localhost:9200/_plugin/kibana/#/discover?_a=(index:'maillog-*',query:(query_string:(query:'digest:%{digest}')))"
 header_links:

--- a/config/sisito.yml
+++ b/config/sisito.yml
@@ -12,6 +12,7 @@ smtp:
     port: 25
     enable_starttls_auto: false
 default_recent_days: 14
+enable_bounce_mail_select_on_no_query: false
 digest: sha1
 #mail_link: "https://localhost:9200/_plugin/kibana/#/discover?_a=(index:'maillog-*',query:(query_string:(query:'digest:%{digest}')))"
 header_links:

--- a/config/sisito.yml
+++ b/config/sisito.yml
@@ -12,7 +12,7 @@ smtp:
     port: 25
     enable_starttls_auto: false
 default_recent_days: 14
-only_searched_bounce_mails: true
+show_all_bounce_mails: false
 digest: sha1
 #mail_link: "https://localhost:9200/_plugin/kibana/#/discover?_a=(index:'maillog-*',query:(query_string:(query:'digest:%{digest}')))"
 header_links:


### PR DESCRIPTION
bounce_mailsの件数が大量になると、`/bounce_mails`の初期表示が非常に遅くなる
そのため `email` or `digest` が指定されていないときは bounce mail の検索を行わない挙動にする設定を追加した。